### PR TITLE
Add general moderation strike event (2023)

### DIFF
--- a/timeline_data.json
+++ b/timeline_data.json
@@ -1,6 +1,30 @@
 {
   "items": [
     {
+      "classes": ["featured-event"],
+      "slug": "general-moderation-strike-starts",
+      "type": "moderators curators strike",
+      "date_str": "2023-06-05",
+      "title": "General moderation strike starts",
+      "summary": "Strikers stop all moderation and curation activities in protest of actions by Stack Exchange, Inc.",
+      "body": "<p>On June 5th, 2023, a number of moderators and curators all over the network called for an indefinite general moderation strike in protest of actions taken by Stack Exchange, Inc. regarding the policy on AI-generated content, as well as of its continuous mistreatment and malignment of volunteers.</p><p>Related:</p>\n<ul>\n<li>Jon Ericson's blog: <a href=\"https://jlericson.com/2023/06/04/signing_on.html\" target=\"_blank\" rel=\"noopener\">Why I'm signing the Stack Overflow strike letter</a></li>\n<li>Monica Chellio's blog: <a href=\"https://cellio.org/blog/2023/stack-overflow-strike\" target=\"_blank\" rel=\"noopener\">Stack Overflow is alienating its community again</a></li>\n</ul>",
+      "links": [
+        {
+          "text": "Open Letter",
+          "url": "https://openletter.mousetail.nl/"
+        },
+        {
+          "text": "MSE post",
+          "url": "https://meta.stackexchange.com/q/389811"
+        },
+        {
+          "text": "MSO post",
+          "url": "https://meta.stackoverflow.com/q/425000"
+        }
+      ],
+      "tags": []
+    },
+    {
       "classes": ["tag-moderator", "tag-resignation"],
       "slug": "ortolano-resigns",
       "type": "moderator resignation",


### PR DESCRIPTION
This PR adds the elephant-in-the-room event: general moderation strike starting on June 5th, 2023.