### PR TITLE
Enabling super- and subscripts in the body editor + minor typo fixes

### DIFF
--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -65,7 +65,7 @@ const toSlug = str => str?.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-
     draggable_modal: true,
     elementpath: true,
     plugins: 'anchor autolink charmap code emoticons image link lists media searchreplace',
-    toolbar: 'bold italic underline link blockquote numlist bullist removeformat | undo redo | searchreplace code',
+    toolbar: 'bold italic underline superscript subscript link blockquote numlist bullist removeformat | undo redo | searchreplace code',
     menubar: false,
     statusbar: true,
     min_height: 320,

--- a/timeline_data.json
+++ b/timeline_data.json
@@ -7,7 +7,7 @@
       "date_str": "2023-06-05",
       "title": "General moderation strike starts",
       "summary": "Strikers stop all moderation and curation activities in protest of actions by Stack Exchange, Inc.",
-      "body": "<p>On June 5th, 2023, a number of moderators and curators all over the network called for an indefinite general moderation strike in protest of actions taken by Stack Exchange, Inc. regarding the policy on AI-generated content, as well as of its continuous mistreatment and malignment of volunteers.</p><p>Related:</p>\n<ul>\n<li>Jon Ericson's blog: <a href=\"https://jlericson.com/2023/06/04/signing_on.html\" target=\"_blank\" rel=\"noopener\">Why I'm signing the Stack Overflow strike letter</a></li>\n<li>Monica Chellio's blog: <a href=\"https://cellio.org/blog/2023/stack-overflow-strike\" target=\"_blank\" rel=\"noopener\">Stack Overflow is alienating its community again</a></li>\n</ul>",
+      "body": "<p>On June 5<sup>th</sup>, 2023, a number of moderators and curators all over the network called for an indefinite general moderation strike in protest of actions taken by Stack Exchange, Inc. regarding the policy on AI-generated content, as well as of its continuous mistreatment and malignment of volunteers.</p><p>Related:</p>\n<ul>\n<li>Jon Ericson's blog: <a href=\"https://jlericson.com/2023/06/04/signing_on.html\" target=\"_blank\" rel=\"noopener\">Why I'm signing the Stack Overflow strike letter</a></li>\n<li>Monica Cellio's blog: <a href=\"https://cellio.org/blog/2023/stack-overflow-strike\" target=\"_blank\" rel=\"noopener\">Stack Overflow is alienating its community again</a></li>\n</ul>",
       "links": [
         {
           "text": "Open Letter",


### PR DESCRIPTION
This PR enables subscript and superscript TinyMCE toolbar buttons, as well as fixes a couple of typos in the general moderation strike (2023) start event.